### PR TITLE
Fix duplicate package detection bug on import.

### DIFF
--- a/lib/Pinto/Role/PackageImporter.pm
+++ b/lib/Pinto/Role/PackageImporter.pm
@@ -106,7 +106,7 @@ sub import_prerequisites {
              my $prereq_vname = "$prereq->{name}-$prereq->{version}";
              $self->whine("Skipping prerequisite $prereq_vname. $_");
              # Mark the prereq as done so we don't try to import it again
-             $done{ $prereq->{name} } = $prereq;
+             $done{ $prereq->{name} } = $prereq->{version};
              undef;  # returned by try{}
         };
 


### PR DESCRIPTION
This fixes an issue where in certain circumstances an import
will fail with "Invalid version format (non-numeric data)"
because $done{$name} contains a hash instead of a version
object.  Makes sure $done{$name} is set to a version object.
