### PR TITLE
add some dist.ini details

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,15 @@ copyright_year   = 2011
 
 version          = 0.038
 
+; authordep Pod::Weaver::Plugin::StopWords
+; authordep Pod::Weaver::Section::Support
+
+[MetaResources]
+repository.type   = git
+repository.url    = git://github.com/thaljef/Pinto.git
+repository.web    = https://github.com/thaljef/Pinto
+bugtracker.web    = https://github.com/thaljef/Pinto/issues
+
 [GatherDir]         ; everything under top dir
 [PruneCruft]        ; default stuff to skip
 [ManifestSkip]      ; if -f MANIFEST.SKIP, skip those, too


### PR DESCRIPTION
I had to add those details to locally do dzil commands.
- define hidden authordeps that did not came with other dependencies and
- add meta about repository and bugtracker that other plugins complain about otherwise

Though, I'm no dzil expert, there is a chance I did something wrong...
