### PR TITLE
'add' allows --force if the archive already exists

### DIFF
--- a/t/22-add-force.t
+++ b/t/22-add-force.t
@@ -1,0 +1,72 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Pinto::Tester;
+use Pinto::Tester::Util qw(make_dist_archive);
+
+#------------------------------------------------------------------------------
+
+my $auth     = 'ME';
+my $dist     = 'Foo-Bar-0.01';
+
+my $pkg1     = 'Foo~0.01';
+my $pkg2     = 'Bar~0.01';
+my $archive1 = make_dist_archive("$dist=$pkg1,$pkg2");
+
+my $pkg3     = 'Baz~0.01';
+my $archive2 = make_dist_archive("$dist=$pkg1,$pkg2,$pkg3");
+
+#-----------------------------------------------------------------------------
+# Add --force ...
+
+{
+  my $t = Pinto::Tester->new;
+
+  # other archive, same name, more pkgs
+
+  # add pkg first time
+  $t->run_ok('Add', {archives => $archive1, author => $auth});
+  $t->registration_ok("$auth/$dist/$pkg1/init/-");
+  $t->registration_ok("$auth/$dist/$pkg2/init/-");
+  $t->registration_not_ok("$auth/$dist/$pkg3/init/-");
+
+  # Copy to a stack that already exists
+  $t->run_ok('Copy', {from_stack => 'init',
+                      to_stack   => 'dev'});
+  $t->registration_ok("$auth/$dist/$pkg1/dev/-");
+  $t->registration_ok("$auth/$dist/$pkg2/dev/-");
+  $t->registration_not_ok("$auth/$dist/$pkg3/dev/-");
+
+  # Pin Foo-Bar in dev
+  $t->run_ok('Pin', {targets => "Bar", stack => 'dev' });
+  $t->registration_ok("$auth/$dist/$pkg1/dev/+");
+  $t->registration_ok("$auth/$dist/$pkg2/dev/+");
+  $t->registration_not_ok("$auth/$dist/$pkg3/dev/+");
+
+  # second stack not affected from first add
+  $t->registration_not_ok("$auth/$dist/$pkg1/dev/+");
+  $t->registration_not_ok("$auth/$dist/$pkg2/dev/+");
+  $t->registration_not_ok("$auth/$dist/$pkg3/dev/+");
+
+  # second add with force
+  $t->run_ok( 'Add', {archives => $archive2, author => $auth, force => 1},
+              'Can force to add same dist twice' );
+
+  # init stack updated to all new packages
+  $t->registration_ok("$auth/$dist/$pkg1/init/-");
+  $t->registration_ok("$auth/$dist/$pkg2/init/-");
+  $t->registration_ok("$auth/$dist/$pkg3/init/-");
+
+  # second stack also updated to all new packages
+  $t->registration_ok("$auth/$dist/$pkg1/dev/+");
+  $t->registration_ok("$auth/$dist/$pkg2/dev/+");
+  $t->registration_ok("$auth/$dist/$pkg3/dev/+");
+}
+
+#-----------------------------------------------------------------------------
+
+done_testing;


### PR DESCRIPTION
And here we go. 

I am very serious about the feature and willing to polish it 
in whatever way you request, in order to not require me
to maintain my own branch forever, as I definitely need it,
twice: for my private Perl::Formance work and my professional
Tapper staging area deployment.

I added tests, manually reviewed the resulting DB schema changes (sql dump diffs),
tried to follow your coding style, and checked the changes with Perl::Critic.

It adds a feature to Pinto I already exercised with my self-made
mirrors, with CPAN::Site, and also with CPAN::Mini::Inject IIRC.

Technically it "just" replaces an existing archive in the repository.

Use cases are:
- hotfix an archive
- use Pinto as staging area before upload to CPAN - without inflating version numbers

Please apply.

Thanks!

Kind regards,
Steffen

---

PS: here the description from the patch:

Usually if the package already exists (e.g., because it has the same
version number) you cannot add it twice.

With this option you can.

It drops the existing archive file from the repository and adds the
new one back again. It registers it for the original stacks, restores
the original pinning, and it recursively pulls all the prerequisites
(unless C<--norecurse> is set), for each of the original stacks.

With this option you can hotfix a repository or use your repository as
an experimental staging area before you upload to CPAN - without
inflating version numbers. Only use it when you know what you are
doing.
