### PR TITLE
fix index Last-Updated: to comply with CPAN.pm

### DIFF
--- a/lib/Pinto/IndexWriter.pm
+++ b/lib/Pinto/IndexWriter.pm
@@ -7,6 +7,7 @@ use MooseX::Types::Moose qw(Bool);
 
 use PerlIO::gzip;
 use Path::Class qw(file);
+use HTTP::Date qw(time2str);
 
 use Pinto::Exception qw(throw);
 use Pinto::Types qw(File Io);
@@ -77,7 +78,7 @@ Columns:      package name, version, path
 Intended-For: Automated fetch routines, namespace documentation.
 Written-By:   Pinto::IndexWriter $version
 Line-Count:   $line_count
-Last-Updated: @{[ scalar localtime() ]}
+Last-Updated: @{[ time2str(time) ]}
 
 END_PACKAGE_HEADER
 


### PR DESCRIPTION
02packages contains a header

  Last-Updated: Fri, 17 Aug 2012 13:13:56 GMT

which CPAN.pm expects to be a time formatted with
HTTP::Date, and not just stringified localtime().
