### PR TITLE
Don't parse the required version of perl

### DIFF
--- a/lib/Pinto/PackageExtractor.pm
+++ b/lib/Pinto/PackageExtractor.pm
@@ -136,9 +136,9 @@ sub requires {
 
     my @prereqs;
     for my $pkg_name (sort keys %prereqs) {
-        my $pkg_ver = version->parse( $prereqs{$pkg_name} );
-
         next if $pkg_name eq 'perl';
+
+        my $pkg_ver = version->parse( $prereqs{$pkg_name} );
 
         next if exists $self->prereq_filter->{$pkg_name}
           and $self->prereq_filter->{$pkg_name} >= $pkg_ver;


### PR DESCRIPTION
I ran into an old version of version.pm which has this in its META.yml.
https://metacpan.org/source/JPEACOCK/version-0.76/META.yml

```
requires:
  perl: '> 5.005'
```

This is valid meta spec, but an invalid version.  Worked around it by bailing out
as early as possible on a Perl version.  The real fix is to read these versions
using CPAN::Meta.

I couldn't figure out how to write a test for it.  Suggestions?
