### PR TITLE
regex quoting in t/20-add.t

### DIFF
--- a/t/20-add.t
+++ b/t/20-add.t
@@ -60,7 +60,7 @@ my $archive = make_dist_archive("$dist=$pkg1,$pkg2");
   $t->registration_ok("$auth/$dist/$pkg1/master");
   $t->registration_ok("$auth/$dist/$pkg2/master");
 
-  $t->stderr_like(qr/$archive is the same/, 'Got warning about identical dist');
+  $t->stderr_like(qr/\Q$archive\E is the same/, 'Got warning about identical dist');
  
   # This time, with a pin
   $t->run_ok('Add', {archives => $archive, author => $auth, pin => 1});
@@ -85,7 +85,7 @@ my $archive = make_dist_archive("$dist=$pkg1,$pkg2");
   $t->registration_ok("$auth/$dist/$pkg1/dev");
   $t->registration_ok("$auth/$dist/$pkg2/dev");
 
-  $t->stderr_like(qr/$archive is the same/, 'Got warning about identical dist');
+  $t->stderr_like(qr/\Q$archive\E is the same/, 'Got warning about identical dist');
 
 }
 
@@ -103,7 +103,7 @@ my $archive = make_dist_archive("$dist=$pkg1,$pkg2");
   $t->registration_ok("$auth/$dist/$pkg1/master/*");
   $t->registration_ok("$auth/$dist/$pkg2/master/*");
 
-  $t->stderr_like(qr/$archive is the same/, 'Got warning about identical dist');
+  $t->stderr_like(qr/\Q$archive\E is the same/, 'Got warning about identical dist');
 
 }
 
@@ -122,7 +122,7 @@ my $archive = make_dist_archive("$dist=$pkg1,$pkg2");
   my $t = Pinto::Tester->new;
   $t->run_ok('Add', {archives => $archive1, author => $auth});
   $t->run_throws_ok('Add', {archives => $archive2, author => $auth}, 
-    qr/$archive2 is the same .* but with different name/);
+    qr/\Q$archive2\E is the same .* but with different name/);
 
 }
 


### PR DESCRIPTION
Hi Jeffrey,

On Mac OS-X one test using unescaped regexes for temporary paths sometimes fails, because sometimes paths contain "+" symbols and might look like:

/var/folders/Gr/GrrPQglwG7uGl2Ox6RCFD++++TU/-Tmp-/uZHXRZrOWA/authors/id/M/ME/ME/CHECKSUMS should exist

This pull requests puts \Q ... \E around the parts to make this test pass on OS-X. I do not see any negative side effects on other unix-flavours.

Best,
Wolfgang
