### PR TITLE
'pinto manual foobar' gives back an irrelevant manpage

### DIFF
--- a/lib/App/Pinto/Command/manual.pm
+++ b/lib/App/Pinto/Command/manual.pm
@@ -36,6 +36,12 @@ sub execute {
     my ( $cmd, undef, undef ) = $self->app->prepare_command(@$args);
 
     my $class = ref $cmd;
+
+    # (An invalid command name was specified; the fallback was returned)
+    if ( $class eq 'App::Cmd::Command::commands' ) {
+        return 1;
+    }
+
     ( my $relative_path = $class ) =~ s< :: ></>xmsg;
     $relative_path .= '.pm';
 

--- a/xt/help/50-manual_cmd.t
+++ b/xt/help/50-manual_cmd.t
@@ -23,6 +23,28 @@ use FindBin qw( $Bin );
     );
 }
 
+{
+    run_cmd_and_trap( 'manual', 'foobar' );
+
+    like(
+        $trap->stdout, qr/unrecognized command/i,
+        qq['foobar' doesn't exist]
+    );
+
+    unlike(
+        $trap->stdout, qr/App::Cmd::Command::commands/,
+        qq[A wrong manpage is not returned]
+    );
+
+    TODO: {
+        local $TODO = 'Difficult to subvert App::Cmd here';
+        unlike(
+            $trap->stdout, qr/Usage:/,
+            qq[Usage is not attempted to be printed]
+        );
+    };
+}
+
 # (App::Cmd::Tester doesn't capture pod2usage() pager output)
 sub run_cmd_and_trap {
     my (@args) = @_;


### PR DESCRIPTION
### Issue

This is a very minor annoyance.

Currently, if an invalid command name is given to `pinto`:
- App::Cmd reports that the command name is invalid
- pod2usage() is still executed thereafter, returning the Pod for App::Cmd::Command::commands (which is irrelevant).
### Fix

This pull request implements the following:
- Add a test in `xt/` for the output of `pinto manual ...`, using Test::Trap
- If an invalid command name is specified, return() immediately
### Aftermath

The irrelevant manpage is no longer shown, but some incomplete Usage information is still returned:

```
$ perl -Ilib bin/pinto manual foobar
Unrecognized command: foobar.

Usage:
```

...there is a TODO test for this bit.
