### PR TITLE
Fix use of uninitialized value in concatenation (.) or string at t/lib/Pinto/Server/Tester.pm line 91

### DIFF
--- a/t/lib/Pinto/Server/Tester.pm
+++ b/t/lib/Pinto/Server/Tester.pm
@@ -63,6 +63,7 @@ has server_host => (
     isa      => Str,
     init_arg => undef,
     default  => 'localhost',
+    lazy     => 1,
 );
 
 =attr server_pid


### PR DESCRIPTION
Displays an error when you run the tests on debian sid perl 5.18.1:

```
t/03-remote/02-responses.t .......... ok
t/03-remote/03-install.t ............ Use of uninitialized value in concatenation (.) or string at t/lib/Pinto/Server/Tester.pm line 91.
t/03-remote/03-install.t ............ 7/? Use of uninitialized value in concatenation (.) or string at t/lib/Pinto/Server/Tester.pm line 91.
t/03-remote/03-install.t ............ ok
t/03-remote/04-install-with-auth.t .. Use of uninitialized value in concatenation (.) or string at t/lib/Pinto/Server/Tester.pm line 91.
t/03-remote/04-install-with-auth.t .. ok
t/04-server/01-functional.t ......... ok
```

t/lib/Pinto/Server/Tester.pm:

``` perl
87  has server_url => (
88      is       => 'ro',
89      isa      => Uri,
90      init_arg => undef,
91      default  => sub { URI->new( 'http://' . $_[0]->server_host . ':' . $_[0]->server_port ) },
92  );
```

Displayed warning because $_[0]->server_host is undef.

During object construction, defaults are not generated in a predictable order,
so you cannot count on some other attribute being populated when generating a
default.
