### PR TITLE
Mention other Docs in the Tutorial

### DIFF
--- a/lib/Pinto/Manual/Tutorial.pod
+++ b/lib/Pinto/Manual/Tutorial.pod
@@ -429,4 +429,14 @@ tutorial, and there are some commands that were not mentioned here at
 all.  So you are encouraged to explore the manual pages for each
 command and learn more.
 
+=head1 SEE ALSO
+
+L<Pinto::Manual::QuickStart>
+
+L<Pinto::Manual::Installing>
+
+L<Pinto> (the library)
+
+L<pinto> (the command)
+
 =cut


### PR DESCRIPTION
A lot of people will read the tutorial first and miss the part about installing (they will think `cpanm Pinto` should do the trick, but they are wrong). So I mentioned it in the introduction and added the SEE ALSO.
