### PR TITLE
Support path preservation in the root URI

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,6 +55,7 @@ Module::Build::CleanInstall = 0.05
 Test::More                  = 0.96               ; for done_testing()
 Module::Faker::Dist         = 0.014              ; works on old perls
 Apache::Htpasswd            = 0
+Hash::Merge                 = 0.200
 
 [Prereqs / RuntimeRequires]           ; prereqs that aren't findable
 DBD::SQLite                 = 1.33               ; not use`d directly

--- a/lib/Pinto/Remote/Action.pm
+++ b/lib/Pinto/Remote/Action.pm
@@ -82,7 +82,10 @@ sub _make_request {
     my $request_body = $args{body} || $self->_make_request_body;
 
     my $uri = URI->new( $self->root );
-    $uri->path_segments( '', 'action', lc $action_name );
+
+    # Preserve the path component of the URI, appending the action part
+    my @segments = ( '', grep { /\S/ } $uri->path_segments );
+    $uri->path_segments( @segments, 'action', lc $action_name );
 
     my $request = POST(
         $uri,

--- a/t/03-remote/01-requests.t
+++ b/t/03-remote/01-requests.t
@@ -15,9 +15,81 @@ use Pinto::Remote;
 use Pinto::Globals;
 use Pinto::Constants qw($PINTO_DEFAULT_COLORS);
 
+use Hash::Merge;
+
 #-----------------------------------------------------------------------------
 
 {
+    my $temp        = File::Temp->new;
+
+    my %defaults = (
+        pinto_args   => {
+            username  => 'myname',
+        },
+        chrome_args  => {
+            verbose   => 2,
+            no_color  => 1,
+            quiet     => 0,
+            colors    => $PINTO_DEFAULT_COLORS,
+        },
+        expected => {
+            method => 'POST',
+            map { $_ => '__unchanged__' } qw(pinto_args chrome_args)
+        },
+    );
+
+    my @cases = (
+        {
+            action => 'Add',
+            root => 'myhost',
+            root_uri_type => 'host only',
+            action_args  => {
+                archives  => [ $temp->filename ],
+                author    => 'ME',
+                stack     => 'mystack',
+            },
+            expected => {
+                uri => 'http://myhost:3111/action/add',
+                action_args => '__unchanged__',
+            },
+        },
+        {
+            action => 'List',
+            root => 'myhost',
+            root_uri_type => 'host only',
+            expected => {
+                uri => 'http://myhost:3111/action/list',
+            },
+        },
+        {
+            action => 'List',
+            root => 'myhost/path',
+            root_uri_type => 'only host and path',
+            expected => { uri => 'http://myhost:3111/path/action/list' },
+        },
+        {
+            action => 'List',
+            root => 'http://myhost/path',
+            root_uri_type => 'scheme and path',
+            expected => { uri => 'http://myhost/path/action/list' },
+        },
+        {
+            action => 'List',
+            root => 'http://myhost:80/path',
+            root_uri_type => 'scheme, port and path',
+            expected => { uri => 'http://myhost:80/path/action/list' },
+        },
+    );
+
+    for my $case (@cases) {
+        my $args = Hash::Merge::merge($case, \%defaults);
+        check_request(%$args);
+    }
+}
+
+sub check_request {
+    my %args = @_;
+    my ($pinto_args, $chrome_args, $action_args) = @args{qw(pinto_args chrome_args action_args)};
 
     local $ENV{PINTO_COLORS} = undef;
     my $ua = local $Pinto::Globals::UA = Test::LWP::UserAgent->new;
@@ -25,32 +97,49 @@ use Pinto::Constants qw($PINTO_DEFAULT_COLORS);
     my $res = HTTP::Response->new(200);
     $ua->map_response( qr{.*} => $res );
 
-    my $action      = 'Add';
-    my $temp        = File::Temp->new;
-    my %pinto_args  = ( username => 'myname' );
-    my %chrome_args = ( verbose => 2, no_color => 1, quiet => 0, colors => $PINTO_DEFAULT_COLORS );
-    my %action_args = ( archives => [ $temp->filename ], author => 'ME', stack => 'mystack' );
-
-    my $chrome = Pinto::Chrome::Term->new(%chrome_args);
-    my $pinto = Pinto::Remote->new( root => 'myhost', chrome => $chrome, %pinto_args );
-    $pinto->run( $action, %action_args );
+    my $chrome = Pinto::Chrome::Term->new(%$chrome_args);
+    my $pinto = Pinto::Remote->new( root => $args{root}, chrome => $chrome, %$pinto_args );
+    $pinto->run( $args{action}, %$action_args );
 
     my $req = $ua->last_http_request_sent;
 
-    is $req->method, 'POST', "Correct HTTP method in request for action $action";
+    my $expected = $args{expected};
+    unless ($expected) {
+        warn "No expected values for action $args{action}";
+    }
 
-    is $req->uri, 'http://myhost:3111/action/add', "Correct uri in request for action $action";
+    if (exists $expected->{method}) {
+        is $req->method, $expected->{method}, "Correct HTTP method in request for action $args{action}";
+    }
 
-    my $req_params      = parse_req_params($req);
-    my $got_chrome_args = decode_json( $req_params->{chrome} );
-    my $got_pinto_args  = decode_json( $req_params->{pinto} );
-    my $got_action_args = decode_json( $req_params->{action} );
+    if (exists $expected->{uri}) {
+        is $req->uri, $expected->{uri}, "Correct uri in request for action $args{action}"
+            . ($args{root_uri_type} ? ", root URI: $args{root_uri_type}" : '');
+    }
 
-    is_deeply $got_chrome_args, \%chrome_args, "Correct chrome args in request for action $action";
+    my $req_params = parse_req_params($req);
+    my %got = (
+        chrome_args => decode_json( $req_params->{chrome} ),
+        pinto_args  => decode_json( $req_params->{pinto} ),
+        action_args => decode_json( $req_params->{action} ),
+    );
 
-    is_deeply $got_pinto_args, \%pinto_args, "Correct pinto args in request for action $action";
+    for my $arg_name (sort keys %got) {
+        if (exists $expected->{$arg_name}) {
+            my $got_args = $got{$arg_name};
 
-    is_deeply $got_action_args, \%action_args, "Correct action args in request for action $action";
+            my $expected_args;
+            if ($expected->{$arg_name} eq '__unchanged__') {
+                $expected_args = $args{$arg_name};
+            } else {
+                $expected_args = $expected->{$arg_name};
+            }
+
+            (my $nice_name = $arg_name) =~ s/_/ /g;
+
+            is_deeply $got_args, $expected_args, "Correct $nice_name in request for action $args{action}";
+        }
+    }
 }
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
The "root" attribute of Pinto::Remote and Pinto::Remote::Action is now treated
with a bit more care to not clobber the path and port components of the URI.
This allows Pinto::Server to operate at a URI with a path, such as:
http://hostname/my/perl/infrastructure/pinto

In order to test this, some refactoring of 01-requests.t was done, creating
a function to call for the test cases defined in a data structure. To rein
in the size of this structure a defaults hash is merged before the case is
tested.

I hope some of this is useful. Anything I contribute to Pinto is under the
Perl/Artistic license of course.
