### PR TITLE
Check permission before denying access due to concurrent use.

### DIFF
--- a/lib/Pinto/Locker.pm
+++ b/lib/Pinto/Locker.pm
@@ -61,7 +61,7 @@ sub lock {    ## no critic qw(Homonym)
     my $root_dir  = $self->repo->config->root_dir;
     my $lock_file = $root_dir->file('.lock')->stringify;
     my $lock;
-    if ( -w $lock_file ) {
+    if ( -w $root_dir ) {
         $lock     = File::NFSLock->new( $lock_file, $lock_type, $LOCKFILE_TIMEOUT )
             or throw 'The repository is currently in use -- please try again later';
     }


### PR DESCRIPTION
If a repository is being shared, anyone wanting to use it must have write
permissions. The lock logic only checks for a successful lock and not the
ability to create a lockfile.
