### PR TITLE
Parse large remote responses correctly

### DIFF
--- a/lib/Pinto/Remote/Action.pm
+++ b/lib/Pinto/Remote/Action.pm
@@ -152,9 +152,10 @@ sub _send_request {
 
     my $request = $args{req} || $self->_make_request;
     my $status = 0;
+    my $buffer = '';
 
     # Currying in some extra args to the callback...
-    my $callback = sub { $self->_response_callback( \$status, @_ ) };
+    my $callback = sub { $self->_response_callback( \$status, \$buffer, @_ ) };
     my $response = $self->request( $request, $callback );
 
     if ( not $response->is_success ) {
@@ -168,21 +169,11 @@ sub _send_request {
 #------------------------------------------------------------------------------
 
 sub _response_callback {
-    my ( $self, $status, $data ) = @_;
+    my ( $self, $status, $buffer, $data ) = @_;
 
-    # Each data chunk will be one or more lines ending with \n
-
-    chomp $data;
-    if ( not $data ) {
-
-        # HACK: So that blank lines come out right
-        # Need to find a better way to do this!!
-        $self->chrome->show('');
-        return 1;
-    }
-
-    for my $line ( split m/\n/, $data, -1 ) {
-
+    $data = ${$buffer}.$data;
+    while($data =~ /\G([^\n]*)\n/gc) {
+        my $line = $1;
         if ( $line eq $PINTO_SERVER_STATUS_OK ) {
             ${$status} = 1;
         }
@@ -190,7 +181,6 @@ sub _response_callback {
             $self->chrome->show_progress;
         }
         elsif ( $line eq $PINTO_SERVER_NULL_MESSAGE ) {
-
             # Do nothing, discard message
         }
         elsif ( $line =~ m{^ \Q$PINTO_SERVER_DIAG_PREFIX\E (.*)}x ) {
@@ -200,6 +190,8 @@ sub _response_callback {
             $self->chrome->show($line);
         }
     }
+    #Save leftovers, use them in next packet
+    (${$buffer}) = ($data =~ /\G(.*)$/g);
 
     return 1;
 }


### PR DESCRIPTION
When response comes from remote pinto server it doesn't nessesarily have to
be split by new lines. Original code didn't expect that and server adds newlines
in odd places for commands that return large responses (like 'list').

This patch fixes this behaviour.
