### PR TITLE
Colorize things intelligently

### DIFF
--- a/lib/App/Pinto.pm
+++ b/lib/App/Pinto.pm
@@ -20,6 +20,7 @@ sub global_opt_spec {
     return (
         [ 'root|r=s'           => 'Path to your repository root directory' ],
         [ 'no-color|no-colour' => 'Do not colorize any output' ],
+        [ 'color|colour'       => 'Colorize output' ],
         [ 'password|p=s'       => 'Password for server authentication' ],
         [ 'quiet|q'            => 'Only report fatal errors' ],
         [ 'username|u=s'       => 'Username for server authentication' ],
@@ -38,7 +39,20 @@ sub pinto {
         $global_options->{root} ||= $ENV{PINTO_REPOSITORY_ROOT}
             || $self->usage_error('Must specify a repository root');
 
-        # Discard password and username arguments if this is not a 
+	if(delete($global_options->{color})) {
+	    $global_options->{no_color} = 0;
+	}
+	elsif($global_options->{no_color}) {
+	    #nothing to do
+	}
+	elsif(defined($ENV{PINTO_NO_COLOR})) {
+	    $global_options->{no_color} = !!$ENV{PINTO_NO_COLOR};
+	}
+	else {
+	    $global_options->{no_color} = (!-t STDOUT);
+	}
+
+        # Discard password and username arguments if this is not a
         # remote repository.  StrictConstrutor will not allow them.
         delete @{$global_options}{qw(username password)}
             if not is_remote_repo($global_options->{root});

--- a/lib/Pinto/Chrome/Term.pm
+++ b/lib/Pinto/Chrome/Term.pm
@@ -27,7 +27,7 @@ extends qw( Pinto::Chrome );
 has no_color => (
     is      => 'ro',
     isa     => Bool,
-    default => sub { !!$ENV{PINTO_NO_COLOR} || 0 },
+    default => sub { 0 },
 );
 
 has colors => (


### PR DESCRIPTION
This improves logic that decides weither to use colors in output:

1) If --color or --no-colort params are provided act accordongly
2) IF PINTO_NO_COLOR is defined act accordingly
3) If connected to TTY use color, do not use color if not connected to TTY

This allows things like pinto list | grep Module work more naturally.
