### PR TITLE
Fix for test fails on attempted upgrade

### DIFF
--- a/t/02-bowels/21-add-no-index.t
+++ b/t/02-bowels/21-add-no-index.t
@@ -19,7 +19,7 @@ subtest 'Excluding with exact match' => sub {
 
     my $t       = Pinto::Tester->new;
     my $archive = make_dist_archive('Foo-Bar-0.01 = Foo~0.01; Bar~0.01');
-    $t->run_ok( Add => { archives => $archive, no_index => ['Foo'] } );
+    $t->run_ok( Add => { archives => $archive, no_index => ['Foo'], author => 'AUTHOR' } );
 
     $t->registration_not_ok("AUTHOR/Foo-Bar-0.01/Foo~0.01/master");
     $t->registration_ok("AUTHOR/Foo-Bar-0.01/Bar~0.01/master");
@@ -38,7 +38,7 @@ subtest 'Excluding with regexes' => sub {
 
     my $t       = Pinto::Tester->new;
     my $archive = make_dist_archive('Foo-Bar-0.01 = Foo~0.01; Bar~0.01; Baz~0.01');
-    $t->run_ok( Add => { archives => $archive, no_index => [ '/F', '/r' ] } );
+    $t->run_ok( Add => { archives => $archive, no_index => [ '/F', '/r' ], author => 'AUTHOR' } );
 
     $t->registration_not_ok("AUTHOR/Foo-Bar-0.01/Foo~0.01/master");
     $t->registration_not_ok("AUTHOR/Foo-Bar-0.01/Bar~0.01/master");

--- a/t/02-bowels/24-skip-prereqs.t
+++ b/t/02-bowels/24-skip-prereqs.t
@@ -20,7 +20,7 @@ my $expected_registration = 'AUTHOR/DistA-1/PkgA~1';
 
 subtest 'Skip all missing prereqs when adding' => sub {
 
-    $t2->run_ok( Add => { archives => $archive, skip_all_missing_prerequisites => 1 } );
+    $t2->run_ok( Add => { archives => $archive, skip_all_missing_prerequisites => 1, author => 'AUTHOR' } );
     $t2->stderr_like(qr/Cannot find PkgB~1 anywhere.  Skipping it/);
     $t2->registration_ok($expected_registration);
 };

--- a/t/02-bowels/73-stack-lock.t
+++ b/t/02-bowels/73-stack-lock.t
@@ -53,7 +53,7 @@ use Pinto::Tester::Util qw(make_dist_archive);
     $t->stack_is_not_locked_ok('master');
 
     # Try modifying again
-    $t->run_ok( Add        => { archives => $archive } );
+    $t->run_ok( Add        => { archives => $archive, author => 'AUTHOR'} );
     $t->run_ok( Pin        => { targets  => 'Foo' } );
     $t->run_ok( Unpin      => { targets  => 'Foo' } );
     $t->run_ok( Unregister => { targets  => 'AUTHOR/Foo-2.tar.gz' } );


### PR DESCRIPTION
I got a handful of test fails when attempting to upgrade, after a little digging I found that these were caused by the presence of a ~/.pauserc file - moving it out of the way let the tests pass.

This change allows the tests to pass even when such a file is present.