### PR TITLE
Installation paths

### DIFF
--- a/etc/install.sh
+++ b/etc/install.sh
@@ -96,7 +96,7 @@ fi
 #-----------------------------------------------------------------------------
 # Bootstrap cpanm
 
-CPANM_URL="https://raw.github.com/thaljef/Pinto/master/etc/cpanm"
+CPANM_URL="https://raw.githubusercontent.com/thaljef/Pinto/master/etc/cpanm"
 PINTO_SBIN="$PINTO_HOME/sbin"
 PINTO_CPANM_EXE="$PINTO_SBIN/cpanm"
 

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -96,16 +96,16 @@ fi
 #-----------------------------------------------------------------------------
 # Bootstrap cpanm
 
-CPANM_URL="https://raw.githubusercontent.com/thaljef/Pinto/master/etc/cpanm"
+PINTO_CPANM_URL=${CPANM_URL:="https://raw.githubusercontent.com/thaljef/Pinto/master/etc/cpanm"}
 PINTO_SBIN="$PINTO_HOME/sbin"
 PINTO_CPANM_EXE="$PINTO_SBIN/cpanm"
 
 mkdir -p "$PINTO_SBIN"
 
 if   [ $PINTO_INSTALLER_AGENT = 'curl' ]; then
-	curl --silent --show-error --location $CPANM_URL > "$PINTO_CPANM_EXE"
+	curl --silent --show-error --location $PINTO_CPANM_URL > "$PINTO_CPANM_EXE"
 elif [ $PINTO_INSTALLER_AGENT = 'wget' ]; then 
-	wget --no-verbose --output-document - $CPANM_URL > "$PINTO_CPANM_EXE"
+	wget --no-verbose --output-document - $PINTO_CPANM_URL > "$PINTO_CPANM_EXE"
 else
 	echo "Invalid PINTO_INSTALLER_AGENT ($PINTO_INSTALLER_AGENT)."
         echo "If set, PINTO_INSTALLER_AGENT must be 'curl' or 'wget'".

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -96,7 +96,7 @@ fi
 #-----------------------------------------------------------------------------
 # Bootstrap cpanm
 
-PINTO_CPANM_URL=${CPANM_URL:="https://raw.githubusercontent.com/thaljef/Pinto/master/etc/cpanm"}
+PINTO_CPANM_URL=${PINTO_CPANM_URL:="https://raw.githubusercontent.com/thaljef/Pinto/master/etc/cpanm"}
 PINTO_SBIN="$PINTO_HOME/sbin"
 PINTO_CPANM_EXE="$PINTO_SBIN/cpanm"
 


### PR DESCRIPTION
Let PINTO_CPANM_URL be configured via environment to simplify testing of upgrades to cpanm.
Also, avoid a redirect by setting the default to the new location at https://raw.githubusercontent.com/.
This helps with SSL implementations that get confused by the cert at the origin of the redirect.