### PR TITLE
Clone a stack from a different repository

### DIFF
--- a/lib/App/Pinto/Command/clone.pm
+++ b/lib/App/Pinto/Command/clone.pm
@@ -1,0 +1,104 @@
+# ABSTRACT: clone a new stack from a different repository
+
+package App::Pinto::Command::clone;
+
+use strict;
+use warnings;
+
+#-----------------------------------------------------------------------------
+
+use base 'App::Pinto::Command';
+
+#------------------------------------------------------------------------------
+
+# VERSION
+
+#------------------------------------------------------------------------------
+
+sub opt_spec {
+    my ( $self, $app ) = @_;
+
+    return (
+        [ 'default'         => 'Make the new stack the default stack' ],
+        [ 'description|d=s' => 'Brief description of the stack' ],
+        [ 'lock'            => 'Lock the new stack to prevent changes' ],
+    );
+
+}
+
+#------------------------------------------------------------------------------
+sub validate_args {
+    my ( $self, $opts, $args ) = @_;
+
+    $self->usage_error('Must specify STACK and TO_STACK')
+        if @{$args} != 2;
+
+    return 1;
+}
+
+#------------------------------------------------------------------------------
+
+sub execute {
+    my ( $self, $opts, $args ) = @_;
+
+    my %targets = ( upstream => $args->[0], to_stack => $args->[1] );
+    my $result = $self->pinto->run( $self->action_name, %{$opts}, %targets );
+
+    return $result->exit_status;
+}
+
+#------------------------------------------------------------------------------
+1;
+
+__END__
+
+=pod
+
+=head1 SYNOPSIS
+
+  pinto --root=REPOSITORY_ROOT clone [OPTIONS] UPSTREAM TO_STACK
+
+=head1 DESCRIPTION
+
+This command creates a new stack by cloning a stack on an upstream repository.
+The new stack must not already exist.
+
+Use the L<new|App::Pinto::Command::new> command to create a new empty
+stack, or the L<props|App::Pinto::Command::props> command to change
+a stack's properties after it has been created.
+
+=head1 COMMAND ARGUMENTS
+
+The two required arguments are the URL of stack on the upstream repository and target
+stack.  The URL could be something like:
+
+    https://www.stratopan.com/thaljef/OpenSource/pinto-release 
+
+Stack names must be alphanumeric plus hyphens, underscores, and periods, and
+are not case-sensitive.
+
+=head1 COMMAND OPTIONS
+
+=over 4
+
+=item --default
+
+Also mark the new stack as the default stack.
+
+=item --description=TEXT
+
+=item -d TEXT
+
+Use TEXT for the description of the stack.  If not specified, defaults
+to 'Clone of stack UPSTREAM'.
+
+=item --lock
+
+Also lock the new stack to prevent future changes.  This is useful for
+creating a read-only "tag" of a stack.  You can always use the
+L<lock|App::Pinto::Command::lock> or
+L<unlock|App::Pinto::Command::unlock> commands at a later time.
+
+=back
+
+=cut

--- a/lib/Pinto/Action/Clone.pm
+++ b/lib/Pinto/Action/Clone.pm
@@ -1,0 +1,128 @@
+# ABSTRACT: Create a new stack by cloning from another repository
+
+package Pinto::Action::Clone;
+
+use Moose;
+use MooseX::StrictConstructor;
+use MooseX::Types::Moose qw(Bool Str);
+use MooseX::MarkAsMethods ( autoclean => 1 );
+
+use Pinto::Types qw(StackName StackObject Uri);
+use Pinto::IndexReader;
+use Pinto::Target::Distribution;
+
+#------------------------------------------------------------------------------
+
+# VERSION
+
+#------------------------------------------------------------------------------
+
+extends qw( Pinto::Action );
+
+#------------------------------------------------------------------------------
+
+with qw( Pinto::Role::Committable Pinto::Role::Puller Pinto::Role::UserAgent );
+
+#------------------------------------------------------------------------------
+
+has upstream => (
+    is       => 'ro',
+    isa      => Uri,
+    required => 1,
+    coerce   => 1,
+);
+
+has to_stack => (
+    is        => 'ro',
+    isa       => StackName,
+    required  => 1,
+);
+
+has default => (
+    is      => 'ro',
+    isa     => Bool,
+    default => 0,
+);
+
+has lock => (
+    is      => 'ro',
+    isa     => Bool,
+    default => 0,
+);
+
+has description => (
+    is        => 'ro',
+    isa       => Str,
+    predicate => 'has_description',
+);
+
+#------------------------------------------------------------------------------
+
+around BUILD => sub {
+    my ( $orig, $self ) = @_;
+
+    # XXX this is a bit of a hack. could not get it to work with just 'stack'
+    my $stack = $self->repo->create_stack( name => $self->to_stack );
+    $self->_set_stack($stack);
+
+    return $self->$orig;
+};
+
+#------------------------------------------------------------------------------
+
+sub generate_message_title {
+    my ( $self ) = @_;
+    return join ' ', 'Clone', $_[0]->upstream->as_string, 'to', $_[0]->stack;
+}
+
+#------------------------------------------------------------------------------
+
+sub execute {
+    my ($self) = @_;
+
+    # get the distribution paths from the upstream index
+    my $index = $self->mirror_temporary(
+        $self->upstream . '/modules/02packages.details.txt.gz'
+    );
+    my $reader = Pinto::IndexReader->new(index_file => $index);
+    my %paths = (
+      map { $_->{path} => 1 }               # remove duplicates
+      grep { $_->{path} !~ m{F/FA/FAKE/perl-} } # skip the fake perl modules
+      values %{ $reader->packages }
+    );
+
+    # pull down all the corresponding distributions
+    # note: we are not using upstream as a source
+    my $stack = $self->stack;
+    for my $path (keys %paths) {
+        $path =~ s{\w/\w\w/}{};
+        $self->notice( "Pulling target $path to stack $stack");
+        my $dist = Pinto::Target::Distribution->new($path);
+        $self->pull(target => $dist);
+    }
+
+    # finalise the stack
+    my $upstream = $self->upstream->as_string;
+    my $description =
+          $self->has_description
+        ? $self->description
+        : "Clone of stack from $self->upstream";
+
+    $stack->set_description($description);
+    $stack->mark_as_default if $self->default;
+    $stack->lock            if $self->lock;
+
+    $self->chrome->progress_done;
+
+    return $self->result->changed;
+}
+
+#------------------------------------------------------------------------------
+
+__PACKAGE__->meta->make_immutable;
+
+#------------------------------------------------------------------------------
+
+1;
+
+__END__

--- a/lib/Pinto/Role/Puller.pm
+++ b/lib/Pinto/Role/Puller.pm
@@ -100,7 +100,7 @@ sub pull {
         $dist = $self->find( target => $target );
     }
     else {
-        throw "Illeagal arguments";
+        throw "Illegal arguments";
     }
 
     $did_register = $dist->register( stack => $stack, pin => $self->pin, force => $self->force );


### PR DESCRIPTION
This was a quick hack to implement a repository cloning command.

In order to fully test the installer, I needed a copy of 'pinto-release'
stack that I could play with freely. 

Very late night hacking, so the code may be a bit rough :-(