### PR TITLE
Improve target_perl_version documentation

### DIFF
--- a/lib/App/Pinto/Command/props.pm
+++ b/lib/App/Pinto/Command/props.pm
@@ -122,7 +122,11 @@ core and therefore does not need to be added to the stack.
 It must be a version string or number for an existing perl release, 
 and cannot be later than the latest version specified in your
 L<Module::CoreList>.  To target even newer perls, just install the 
-latest version of L<Module::CoreList>.
+latest version of L<Module::CoreList>.  Remember that Pinto is often
+installed as a stand-alone application, so you will need to update
+Pinto's copy of L<Module::CoreList> - for example:
+
+ cpanm -L /opt/local/pinto/ Module::CoreList
 
 =back
 

--- a/lib/Pinto/Types.pm
+++ b/lib/Pinto/Types.pm
@@ -109,7 +109,7 @@ coerce Version,
 
 subtype PerlVersion, as Object,
     where { $_->isa('version') && exists $Module::CoreList::version{ $_->numify + 0 } },
-    message {"perl version ($_) is unknown to me"};
+    message {"perl version ($_) is unknown to me; try updating Pinto's copy of Module::CoreList"};
 
 coerce PerlVersion,
     from Str, via { version->parse($_) };


### PR DESCRIPTION
Module::CoreList is used to validate the Perl version number supplied to
the target_perl_version (tpv) property when creating a new stack.
Module::CoreList must be updated if you need to use a version of Perl
that is later than the ones it supports.  This revision clarifies that
it is Pinto's copy of Module::CoreList that must be updated.  It also
adds this information to the associated error message.