### PR TITLE
Fix typo in text and link: "commmand"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1696,7 +1696,7 @@
      I might add later).
 
      All commands for pinto-admin[1] now support a --man option, which
-     shows you the full documentation for a commmand.  But at this
+     shows you the full documentation for a command.  But at this
      point, I haven't written the documentation for all the commands.
 
      Several of the commands for pinto-admin[1] now support a --tag

--- a/bin/pinto
+++ b/bin/pinto
@@ -239,7 +239,7 @@ shell username.
 =item C<PINTO_AUTHOR_ID>
 
 Sets the default author identity when the C<--author> option is not specified
-(currently, only used by the L<add|App::Pinto::Commmand::add> command).  Defaults
+(currently, only used by the L<add|App::Pinto::Command::add> command).  Defaults
 to your current shell username.  By PAUSE convention, all author id's are forced
 to uppercase.
 
@@ -287,7 +287,7 @@ expire it.  The default is 0 (don't expire).  This variable only has effect when
 =item C<PINTO_SHELL>
 
 Sets the path to the command pinto will use for interactive shells (like with the
-L<look|App::Pinto::Commmand::look> command). If this is not set, pinto defaults
+L<look|App::Pinto::Command::look> command). If this is not set, pinto defaults
 to either C<SHELL> or C<COMSPEC>.
 
 =back


### PR DESCRIPTION
Fixing the broken 'add' and 'look' Perldoc links.

thanks,
Michael