### PR TITLE
Fix passing --stack to revert

### DIFF
--- a/lib/App/Pinto/Command/revert.pm
+++ b/lib/App/Pinto/Command/revert.pm
@@ -43,7 +43,10 @@ sub validate_args {
     # If there are 2 args, then the 1st is stack and 2nd is revision
 
     $opts->{revision} = $arg_count == 1 ? $args->[0] : $args->[1];
-    $opts->{stack}    = $arg_count == 2 ? $args->[0] : undef;
+    die "You cannot set the stack both via a flag and positionally\n"
+        if $opts->{stack} && $arg_count == 2;
+
+    $opts->{stack} = $args->[0] if $arg_count == 2;
 
     return 1;
 }


### PR DESCRIPTION
Revert is reasonably documented to take both a positional and named parameter for stack, but the code only respects the positional one.  This pull request allows both to work.
