### PR TITLE
[ContributorsFromGit] -> [Git::Contributors]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -102,7 +102,7 @@ meta_noindex = 1         ; respect prior no_index directives
 [MetaYAML]               ; generate META.yml (v1.4)
 [MetaJSON]               ; generate META.json (v2)
 
-[ContributorsFromGit]
+[Git::Contributors]
 
 ; build system
 [ExecDir]                ; include 'bin/*' as executables


### PR DESCRIPTION
I forked [ContributorsFromGit] to fix longstanding issues on win32 and utf8 character encoding.
