### PR TITLE
lock to Any::Moose@0.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
    - unset PERL_CPANM_OPT
    - cpanm --mirror http://cpan.stratopan.com --quiet --notest Dist::Zilla
    - dzil authordeps | cpanm --mirror http://cpan.stratopan.com --quiet --notest
-   - dzil listdeps   | cpanm --mirror http://cpan.stratopan.com --quiet --notest
+   - dzil listdeps --cpanm-versions | xargs cpanm --mirror http://cpan.stratopan.com --quiet --notest
 
 script:
    - export HARNESS_OPTIONS='j:c'

--- a/dist.ini
+++ b/dist.ini
@@ -57,6 +57,7 @@ Module::Faker::Dist         = 0.014              ; works on old perls
 Apache::Htpasswd            = 0
 
 [Prereqs / RuntimeRequires]           ; prereqs that aren't findable
+Any::Moose                  = == 0.26            ; without deprecated warning
 DBD::SQLite                 = 1.33               ; not use`d directly
 DBIx::Class                 = 0.08200            ; prefetch is fixed
 App::Cmd                    = 0.323              ; built-in "version" command


### PR DESCRIPTION
Since [Any::Moose](https://metacpan.org/source/ETHER/Any-Moose-0.27/lib/Any/Moose.pm#L12) has got noisier about being deprecated CI builds are [failing](https://travis-ci.org/thaljef/Pinto/jobs/205741493#L445-L462).
