### PR TITLE
Add workaround for Term::ReadKey >= 2.37

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 {{$NEXT}}
+      - Fixed indexing of distributions that declare a "provides" for a package
+        with a file attribute of "META.yml" or "META.json".  This is perfectly
+        legal according to the CPAN Meta Spec (GH #240, GH #241).
 
 0.14      2017-08-06 00:09:07-07:00 America/Los_Angeles
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ from your repository :)
 - Karen Etheridge <ether@cpan.org>
 - Michael G. Schwern <schwern@pobox.com>
 - Michael Jemmeson <mjemmeson@cpan.org>
+- Michael Schout <mschout@gkg.net>
 - Mike Raynham <mike.raynham@spareroom.co.uk>
 - Nikolay Martynov <mar.kolya@gmail.com>
 - Oleg Gashev <oleg@gashev.net>

--- a/lib/Pinto/Schema/Result/Package.pm
+++ b/lib/Pinto/Schema/Result/Package.pm
@@ -267,6 +267,11 @@ sub is_simile {
     # package.  In that case we must assume that it is a simile.
     return 1 if not $file;
 
+    # Some dists (e.g.: Term::ReadKey) list the module provides package ->
+    # META.{json,yaml}. This is pefectly fine according to the CPAN Meta Spec.
+    # See GH #241
+    return 1 if $file =~ /^META\.(?:yml|json)$/;
+
     # The following code was taken from simile() in PAUSE/pmfile.pm
 
     # MakeMaker gives them the chance to have the file Simple.pm in
@@ -296,11 +301,6 @@ sub can_index {
     # Workaround for FCGI
     return 1 if $self->name eq 'FCGI'
         and $self->file eq 'FCGI.PL';
-
-    # Workaround for Term::ReadKey (see GH #240)
-    return 1 if $self->name eq 'Term::ReadKey'
-        and $self->version >= version->parse('2.37')
-        and $self->file eq 'META.yml';
 
     return $self->is_simile;
 }

--- a/lib/Pinto/Schema/Result/Package.pm
+++ b/lib/Pinto/Schema/Result/Package.pm
@@ -297,6 +297,11 @@ sub can_index {
     return 1 if $self->name eq 'FCGI'
         and $self->file eq 'FCGI.PL';
 
+    # Workaround for Term::ReadKey (see GH #240)
+    return 1 if $self->name eq 'Term::ReadKey'
+        and $self->version >= version->parse('2.37')
+        and $self->file eq 'META.yml';
+
     return $self->is_simile;
 }
 

--- a/t/02-bowels/21-pull.t
+++ b/t/02-bowels/21-pull.t
@@ -7,7 +7,7 @@ use Test::More;
 
 use lib 't/lib';
 use Pinto::Tester;
-use Pinto::Tester::Util qw(make_dist_archive);
+use Pinto::Tester::Util qw(make_dist_struct make_dist_archive);
 
 #------------------------------------------------------------------------------
 
@@ -128,5 +128,30 @@ subtest 'Allow dry run pull on locked repo' => sub {
     $local->repository_clean_ok;
 
 };
+
+for my $provides_file (qw(META.yml META.json)) {
+    subtest "Pull distribution with package provides file $provides_file" => sub {
+        my $t = Pinto::Tester->new;
+
+        my $struct = make_dist_struct('JOHN/Baz-1.2 = Baz~1.2 & Nuts-2.3');
+
+        # change the provides file
+        $struct->{provides}{Baz}{file} = $provides_file;
+
+        my $archive = make_dist_archive($struct);
+        my $message = "Populated repository";
+
+        my $args = {
+            recurse    => 0,
+            archives   => $archive,
+            author     => $struct->{cpan_author},
+            message    => $message
+        };
+
+        $t->run_ok( 'Add', $args, $message );
+
+        $t->registration_ok('JOHN/Baz-1.2/Baz~1.2');
+    };
+}
 
 done_testing;


### PR DESCRIPTION
As of Term::ReadKey v2.34, Pinto was unable to pull this module.  In
v2.37, the author added Term::ReadKey to the "provides" section of
META.yml.  This workaround fixes can_index() so that Pinto is able to
index Term::ReadKey 2.37 or later.

Fixes #240