### PR TITLE
limit to known phases

### DIFF
--- a/lib/Pinto/PackageExtractor.pm
+++ b/lib/Pinto/PackageExtractor.pm
@@ -108,7 +108,7 @@ sub requires {
                      catch { throw "Unable to extract prereqs from $archive: $_" };
 
     my @prereqs;
-    for my $phase ( keys %{$prereqs_meta} ) {
+    for my $phase ( qw/configure runtime build test/ ) {
 
         # TODO: Also capture the relation (suggested, requires, recomends, etc.)
         # But that will require a schema change to add another column to the table.


### PR DESCRIPTION
I have found with `pinto` that unexpected packages were getting pulled.

For example, the following will pull in `Dist::Zilla` along with its dependency on `Moose`.

```
pinto pull -s test ETHER/Task-Weaken-1.06.tar.gz
```

The culprit appears to be a required packages getting added for the phase:

```
X_Dist_Zilla
```

This patch limits the packages pulled by `pinto` to a known phase: `configure`, `runtime`, `build` or `test`. 