### PR TITLE
fix exit status

### DIFF
--- a/lib/Pinto/Server/Responder/Action.pm
+++ b/lib/Pinto/Server/Responder/Action.pm
@@ -116,7 +116,7 @@ sub child_proc {
 
     print {$writer} $PINTO_PROTOCOL_STATUS_OK . "\n" if $result->was_successful;
 
-    exit $result->was_successful ? 0 : 1;
+    exit($result->was_successful ? 0 : 1);
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $result->was_successful ? 0 : 1` parses as `(exit $result->was_successful) ? 0 : 1`, which is not what was intended.